### PR TITLE
FIX_missing-modules

### DIFF
--- a/python/create_auth_token.py
+++ b/python/create_auth_token.py
@@ -1,5 +1,5 @@
 import time
-
+import uuid
 import jwt
 from jwt.utils import force_bytes
 import requests


### PR DESCRIPTION
Adding missing python module 'uuid' to script. Without the following error occurs during runtime:

```
Traceback (most recent call last):
  File "/Users/xxx/repos/service-account-api-examples/python/create_auth_token.py", line 27, in <module>
    'jti': str(uuid.uuid4()),
               ^^^^
NameError: name 'uuid' is not defined
```